### PR TITLE
adding quotes on output path, in case of blank space breaking ffmpeg command

### DIFF
--- a/src/ofxFFmpegRecorder.cpp
+++ b/src/ofxFFmpegRecorder.cpp
@@ -382,7 +382,7 @@ bool ofxFFmpegRecorder::startCustomRecord()
     args.push_back("-framerate " + std::to_string(m_Fps));
     std::copy(m_AdditionalOutputArguments.begin(), m_AdditionalOutputArguments.end(), std::back_inserter(args));
     
-    args.push_back(m_OutputPath);
+    args.push_back("\""+m_OutputPath+"\"");
 //    args.push_back("-codecs ");
 
     std::string cmd = m_FFmpegPath + " ";
@@ -440,7 +440,7 @@ bool ofxFFmpegRecorder::startCustomAudioRecord()
     args.push_back("-b:a 320k");
     std::copy(m_AdditionalOutputArguments.begin(), m_AdditionalOutputArguments.end(), std::back_inserter(args));
 
-    args.push_back(m_OutputPath);
+    args.push_back("\""+m_OutputPath+"\"");
 
     std::string cmd = m_FFmpegPath + " ";
     for (auto arg : args) {


### PR DESCRIPTION
I had a runtime error of "unable to find a suitable output format for '{some parts of my data path}'" when running the example, and figured out the reason was that my openframeworks was placed inside a folder named with space character. It broke the output part of the FFmpeg command by chopping half of it and treat the other half as another flag. Putting a pair of quotes on the path saved my butt. 👍